### PR TITLE
switching ternary operator to correctly display default tip

### DIFF
--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -348,7 +348,7 @@ router.get('/:username', (req, res) => {
 						"groups":groups, 
 						"friends": foundUser.friends, 
 						"image": foundUser.img, 
-						"tip": req.query.error == undefined ? "Number Needed for Tip" : foundUser.defaultTip
+						"tip": req.query.error == undefined ? foundUser.defaultTip : "Number Needed for Tip"
 					});
 					
 				}


### PR DESCRIPTION
I had the ternary operator backwards, so even with a default tip, it was showing "number needed"